### PR TITLE
Fix GitHub badge contribution fetch

### DIFF
--- a/badger_os/README.md
+++ b/badger_os/README.md
@@ -118,3 +118,10 @@ Display QR codes and associated text.
 
 Display current weather data from the [Open-Meteo weather API](https://open-meteo.com/)
 
+
+### GitHub Badge
+[github_badge.py](examples/github_badge.py)
+
+Fetches your GitHub profile stats and latest repository info over the network.
+It also pulls contribution data from a public API to draw a grid showing your
+recent activity and displays a QR code linking to your profile.

--- a/badger_os/examples/clock.py
+++ b/badger_os/examples/clock.py
@@ -45,7 +45,7 @@ button_down = badger2040.BUTTONS[badger2040.BUTTON_DOWN]
 
 # Button handling function
 def button(pin):
-    global last, set_clock, toggle_set_clock, cursor, year, month, day, hour, minute
+    global toggle_set_clock, cursor, year, month, day, hour, minute
 
     time.sleep(0.01)
     if not pin.value():
@@ -162,7 +162,7 @@ def draw_clock():
 
 
 def draw_second():
-    global second_offset, second_unit_offset
+    global second_unit_offset
 
     display.set_pen(15)
     display.rectangle(second_offset, 8, 75, 56)

--- a/badger_os/examples/github_badge.py
+++ b/badger_os/examples/github_badge.py
@@ -1,0 +1,177 @@
+# This example fetches GitHub profile details and shows them on Badger 2040 W.
+# Fill in your GitHub username in the USERNAME constant.
+
+import badger2040
+from badger2040 import WIDTH
+import urequests
+import qrcode
+import time
+
+# GitHub API requires a User-Agent header
+HEADERS = {"User-Agent": "Badger2040"}
+
+# Replace this with your GitHub username
+USERNAME = "Julian-Elliott"
+
+USER_URL = "https://api.github.com/users/" + USERNAME
+REPO_URL = (
+    "https://api.github.com/users/" + USERNAME + "/repos?per_page=1&sort=pushed"
+)
+
+# URL for contribution data
+CONTRIB_URL = "https://github-contributions-api.jogruber.de/v4/" + USERNAME
+
+# URL used for the QR code
+GITHUB_URL = "https://github.com/" + USERNAME
+
+# QR code setup
+code = qrcode.QRCode()
+
+
+def measure_qr_code(size, code):
+    w, h = code.get_size()
+    module_size = int(size / w)
+    return module_size * w, module_size
+
+
+def draw_qr_code(ox, oy, size, code):
+    size, module_size = measure_qr_code(size, code)
+    display.set_pen(15)
+    display.rectangle(ox, oy, size, size)
+    display.set_pen(0)
+    for x in range(size):
+        for y in range(size):
+            if code.get_module(x, y):
+                display.rectangle(
+                    ox + x * module_size,
+                    oy + y * module_size,
+                    module_size,
+                    module_size,
+                )
+
+
+# Display Setup
+display = badger2040.Badger2040()
+display.led(128)
+display.set_update_speed(2)
+
+display.connect()
+
+# Fetch contribution levels (0-4) from GitHub
+
+
+def get_contributions():
+    global contributions
+    contributions = []
+    year = time.gmtime()[0]
+    url = f"{CONTRIB_URL}?y={year}"
+    try:
+        r = urequests.get(url, headers=HEADERS)
+        data = r.json()
+        contributions = [c.get("level", 0) for c in data.get("contributions", [])][-140:]
+    except Exception as e:
+        print(f"Failed to fetch contributions: {e}")
+        contributions = []
+    finally:
+        try:
+            r.close()
+        except Exception:
+            pass
+
+
+# Draw a simple contributions grid
+def draw_activity(x, y, cols=20, rows=7, cell=4):
+    start = len(contributions) - cols * rows
+    if start < 0:
+        start = 0
+    idx = start
+    for c in range(cols):
+        for r_ in range(rows):
+            if idx < len(contributions):
+                level = contributions[idx]
+                pen = 15 - level * 3
+                display.set_pen(pen)
+                display.rectangle(x + c * cell, y + r_ * cell, cell - 1, cell - 1)
+                idx += 1
+            else:
+                return
+
+
+def get_data():
+    global login, repos, followers, latest_repo, pushed
+    try:
+        r = urequests.get(USER_URL, headers=HEADERS)
+        user = r.json()
+        login = user.get("login", USERNAME)
+        repos = user.get("public_repos", 0)
+        followers = user.get("followers", 0)
+    except Exception as e:
+        print(f"Failed to fetch user info: {e}")
+        login = USERNAME
+        repos = 0
+        followers = 0
+    finally:
+        try:
+            r.close()
+        except Exception:
+            pass
+
+    try:
+        r = urequests.get(REPO_URL, headers=HEADERS)
+        repo_list = r.json()
+        if repo_list and isinstance(repo_list, list):
+            repo = repo_list[0]
+            latest_repo = repo.get("name", "")
+            pushed = repo.get("pushed_at", "").split("T")[0]
+        else:
+            latest_repo = ""
+            pushed = ""
+    except Exception as e:
+        print(f"Failed to fetch repo info: {e}")
+        latest_repo = ""
+        pushed = ""
+    finally:
+        try:
+            r.close()
+        except Exception:
+            pass
+
+
+def draw_page():
+    display.set_pen(15)
+    display.clear()
+    display.set_pen(0)
+
+    display.set_font("bitmap6")
+    display.rectangle(0, 0, WIDTH, 20)
+    display.set_pen(15)
+    display.text("GitHub Badge", 3, 4)
+    display.set_pen(0)
+
+    display.set_font("bitmap8")
+
+    code.set_text(GITHUB_URL)
+    draw_qr_code(WIDTH - 100, 25, 100, code)
+
+    text_width = WIDTH - 105
+
+    display.text(f"User: {login}", 0, 30, text_width, 2)
+    display.text(f"Repos: {repos}", 0, 50, text_width, 2)
+    display.text(f"Followers: {followers}", 0, 70, text_width, 2)
+    draw_activity(0, 90)
+    display.text(f"Pushed: {pushed}", 0, 120, text_width, 2)
+
+    display.update()
+
+
+def main():
+    get_contributions()
+    get_data()
+    draw_page()
+    while True:
+        display.keepalive()
+        display.halt()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- avoid memory errors by switching contribution data to the GitHub Contributions API
- update README description for GitHub Badge example

## Testing
- `python3 -m flake8 --show-source --ignore E501 badger_os`
- `python3 -m flake8 --show-source --ignore E501 badger_os/examples/github_badge.py`
- `python3 -m flake8 --show-source --ignore E501 firmware/PIMORONI_BADGER2040W/lib`
- `python3 -m flake8 --show-source --ignore E501 firmware/PIMORONI_BADGER2040/lib`


------
https://chatgpt.com/codex/tasks/task_e_6841fc9e017483329ea418dbb66ce92b